### PR TITLE
Added AppVeyor integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+version: 1.0.{build}
+build:
+  project: YAXLib.2013.sln
+  verbosity: minimal


### PR DESCRIPTION
Added AppVeyor integration, free for open source projects.

AppVeyor is a build server in the cloud and builds and runs unit tests in every PR. Then you're sure that PR's wont break the build or unit tests. Also you can publish to NuGet.org with a few clicks. 

Now only building `YAXLib.2013.sln`. 

How to set-up:
1. login to AppVeyor (free), with GitHub account or by creating an AppVeyor account
2. press "new project"
3. hover project, press "add"

PS: in a later phase we can added code coverage (free, also cloud service), if you like. 