### PR TITLE
Added YAXElementOrder attribute to order the serialization...

### DIFF
--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -97,6 +97,8 @@ namespace YAXLib
         /// <param name="callerSerializer">The caller serializer.</param>
         public MemberWrapper(MemberInfo memberInfo, YAXSerializer callerSerializer)
         {
+            Order = Int32.MaxValue;
+
             if (!(memberInfo.MemberType == MemberTypes.Property || memberInfo.MemberType == MemberTypes.Field))
                 throw new Exception("Member must be either property or field");
 
@@ -508,6 +510,7 @@ namespace YAXLib
 
         public bool PreservesWhitespace { get; private set; }
 
+        public int Order { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this instance has a custom namespace
@@ -571,7 +574,6 @@ namespace YAXLib
         {
             return m_possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
         }
-
 
 
         // Public Methods
@@ -897,6 +899,10 @@ namespace YAXLib
             else if (attr is YAXDontSerializeIfNullAttribute)
             {
                 IsAttributedAsDontSerializeIfNull = true;
+            }
+            else if (attr is YAXElementOrder)
+            {
+                Order = (attr as YAXElementOrder).Order;
             }
             else
             {

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -510,7 +510,7 @@ namespace YAXLib
 
         public bool PreservesWhitespace { get; private set; }
 
-        public int Order { get; set; }
+        public int Order { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether this instance has a custom namespace

--- a/YAXLib/YAXAttributes.cs
+++ b/YAXLib/YAXAttributes.cs
@@ -294,7 +294,40 @@ namespace YAXLib
 
     }
 
+    /// <summary>
+    /// Prioritizes a field or property for serializing/deserializing.
+    /// Unattributed fields or properties will be serialized/deserialized after attributed ones.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class YAXElementOrder : YAXBaseAttribute
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXElementOrder"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The element this applies to will be given priority in being serialized or deserialized
+        /// depending on the relative value compared to other elements with take on the given XML namespace. The namespace
+        /// will be added to the root XML element, with the given prefix in the form: 
+        ///     xmlns:prefix="namespace"
+        /// </remarks>
+        /// <param name="order">The priority of the element in serializing and deserializing.</param>
+        public YAXElementOrder(int order)
+        {
+            Order = order;
+        }
 
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// The order used to prioritize serialization and deserialization.
+        /// </summary>
+        public int Order
+        { get; private set; }
+
+        #endregion
+    }
 
     /// <summary>
     /// Prevents serialization of some field or property.

--- a/YAXLib/YAXAttributes.cs
+++ b/YAXLib/YAXAttributes.cs
@@ -307,9 +307,7 @@ namespace YAXLib
         /// </summary>
         /// <remarks>
         /// The element this applies to will be given priority in being serialized or deserialized
-        /// depending on the relative value compared to other elements with take on the given XML namespace. The namespace
-        /// will be added to the root XML element, with the given prefix in the form: 
-        ///     xmlns:prefix="namespace"
+        /// depending on the relative value compared to other child elements.
         /// </remarks>
         /// <param name="order">The priority of the element in serializing and deserializing.</param>
         public YAXElementOrder(int order)
@@ -323,8 +321,7 @@ namespace YAXLib
         /// <summary>
         /// The order used to prioritize serialization and deserialization.
         /// </summary>
-        public int Order
-        { get; private set; }
+        public int Order { get; private set; }
 
         #endregion
     }

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -2833,7 +2833,7 @@ namespace YAXLib
         /// <returns>the sequence of fields to be serialized for the serializer's underlying type.</returns>
         private IEnumerable<MemberWrapper> GetFieldsToBeSerialized()
         {
-            return GetFieldsToBeSerialized(m_udtWrapper);
+            return GetFieldsToBeSerialized(m_udtWrapper).OrderBy(t=>t.Order);
         }
 
         /// <summary>

--- a/YAXLibTests/DeserializationTest.cs
+++ b/YAXLibTests/DeserializationTest.cs
@@ -618,7 +618,6 @@ namespace YAXLibTests
             Assert.IsNull(deserializedInstance.Next);
         }
 
-
         [Test]
         public void InfiniteLoopCausedBySerializingCalculatedPropertiesCanBePreventedBySettingDontSerializePropertiesWithNoSetter()
         {
@@ -649,14 +648,23 @@ namespace YAXLibTests
             var second = "";
             var third = "";
             var fourth = "";
+            var fifth = "";
+            var sixth = "";
+            var seventh = "";
             obj.DecentralizationOrder.TryGetValue(0, out first);
             obj.DecentralizationOrder.TryGetValue(1, out second);
             obj.DecentralizationOrder.TryGetValue(2, out third);
             obj.DecentralizationOrder.TryGetValue(3, out fourth);
+            obj.DecentralizationOrder.TryGetValue(4, out fifth);
+            obj.DecentralizationOrder.TryGetValue(5, out sixth);
+            obj.DecentralizationOrder.TryGetValue(6, out seventh);
             Assert.AreEqual(first, "Author");
             Assert.AreEqual(second, "Title");
-            Assert.AreEqual(third, "Price");
-            Assert.AreEqual(fourth, "PublishYear");
+            Assert.AreEqual(third, "PublishYear");
+            Assert.AreEqual(fourth, "Price");
+            Assert.AreEqual(fifth, "Review");
+            Assert.AreEqual(sixth, "Publisher");
+            Assert.AreEqual(seventh, "Editor");
         }
     }
 }

--- a/YAXLibTests/SampleClasses/SimpleBookClassWithOrdering.cs
+++ b/YAXLibTests/SampleClasses/SimpleBookClassWithOrdering.cs
@@ -8,7 +8,7 @@ namespace YAXLibTests.SampleClasses
 {
     [ShowInDemoApplication(SortKey = "003")]
 
-    [YAXComment("This example demonstrates serailizing a very simple struct")]
+    [YAXComment("This example demonstrates serailizing a very simple class, but with partial priority ordering.")]
     public class BookClassWithOrdering
     {
         private string _title;
@@ -19,7 +19,11 @@ namespace YAXLibTests.SampleClasses
 
         [YAXDontSerialize]
         public Dictionary<int, string> DecentralizationOrder = new Dictionary<int, string>();
-            
+
+        private string _review;
+        private string _publisher;
+        private string _editor;
+
         [YAXElementOrder(1)]
         public string Title
         {
@@ -42,7 +46,6 @@ namespace YAXLibTests.SampleClasses
             }
         }
 
-        [YAXElementOrder(3)]
         public int PublishYear
         {
             get { return _publishYear; }
@@ -53,7 +56,6 @@ namespace YAXLibTests.SampleClasses
             }
         }
 
-        [YAXElementOrder(2)]
         public double Price
         {
             get { return _price; }
@@ -61,6 +63,36 @@ namespace YAXLibTests.SampleClasses
             {
                 _price = value;
                 DecentralizationOrder.Add(currentElement++, "Price");
+            }
+        }
+
+        public string Review
+        {
+            get { return _review; }
+            set
+            {
+                _review = value; 
+                DecentralizationOrder.Add(currentElement++, "Review");
+            }
+        }
+
+        public string Publisher
+        {
+            get { return _publisher; }
+            set
+            {
+                _publisher = value; 
+                DecentralizationOrder.Add(currentElement++, "Publisher");
+            }
+        }
+
+        public string Editor
+        {
+            get { return _editor; }
+            set
+            {
+                _editor = value; 
+                DecentralizationOrder.Add(currentElement++, "Editor");
             }
         }
 
@@ -76,7 +108,10 @@ namespace YAXLibTests.SampleClasses
                 Title = "Reinforcement Learning an Introduction",
                 Author = "R. S. Sutton & A. G. Barto",
                 PublishYear = 1998,
-                Price = 38.75
+                Price = 38.75,
+                Publisher = "MIT Press",
+                Review = "This book is very good at being a book.",
+                Editor = "MIT Productions"
             };
         }
     }

--- a/YAXLibTests/SampleClasses/SimpleBookClassWithOrdering.cs
+++ b/YAXLibTests/SampleClasses/SimpleBookClassWithOrdering.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses
+{
+    [ShowInDemoApplication(SortKey = "003")]
+
+    [YAXComment("This example demonstrates serailizing a very simple struct")]
+    public class BookClassWithOrdering
+    {
+        private string _title;
+        private string _author;
+        private int _publishYear;
+        private double _price;
+        private int currentElement = 0;
+
+        [YAXDontSerialize]
+        public Dictionary<int, string> DecentralizationOrder = new Dictionary<int, string>();
+            
+        [YAXElementOrder(1)]
+        public string Title
+        {
+            get { return _title; }
+            set
+            {
+                _title = value;
+                DecentralizationOrder.Add(currentElement++, "Title");
+            }
+        }
+
+        [YAXElementOrder(0)]
+        public string Author
+        {
+            get { return _author; }
+            set
+            {
+                _author = value;
+                DecentralizationOrder.Add(currentElement++, "Author");
+            }
+        }
+
+        [YAXElementOrder(3)]
+        public int PublishYear
+        {
+            get { return _publishYear; }
+            set
+            {
+                _publishYear = value;
+                DecentralizationOrder.Add(currentElement++, "PublishYear");
+            }
+        }
+
+        [YAXElementOrder(2)]
+        public double Price
+        {
+            get { return _price; }
+            set
+            {
+                _price = value;
+                DecentralizationOrder.Add(currentElement++, "Price");
+            }
+        }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public static BookClassWithOrdering GetSampleInstance()
+        {
+            return new BookClassWithOrdering()
+            {
+                Title = "Reinforcement Learning an Introduction",
+                Author = "R. S. Sutton & A. G. Barto",
+                PublishYear = 1998,
+                Price = 38.75
+            };
+        }
+    }
+}

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -173,12 +173,15 @@ namespace YAXLibTests
         public void BookOrderTest()
         {
             const string result =
-@"<!-- This example demonstrates serailizing a very simple struct -->
+@"<!-- This example demonstrates serailizing a very simple class, but with partial priority ordering. -->
 <BookClassWithOrdering>
   <Author>R. S. Sutton &amp; A. G. Barto</Author>
   <Title>Reinforcement Learning an Introduction</Title>
-  <Price>38.75</Price>
   <PublishYear>1998</PublishYear>
+  <Price>38.75</Price>
+  <Review>This book is very good at being a book.</Review>
+  <Publisher>MIT Press</Publisher>
+  <Editor>MIT Productions</Editor>
 </BookClassWithOrdering>";
             var serializer = new YAXSerializer(typeof(BookClassWithOrdering), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
             string got = serializer.Serialize(BookClassWithOrdering.GetSampleInstance());

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -170,6 +170,22 @@ namespace YAXLibTests
         }
 
         [Test]
+        public void BookOrderTest()
+        {
+            const string result =
+@"<!-- This example demonstrates serailizing a very simple struct -->
+<BookClassWithOrdering>
+  <Author>R. S. Sutton &amp; A. G. Barto</Author>
+  <Title>Reinforcement Learning an Introduction</Title>
+  <Price>38.75</Price>
+  <PublishYear>1998</PublishYear>
+</BookClassWithOrdering>";
+            var serializer = new YAXSerializer(typeof(BookClassWithOrdering), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
+            string got = serializer.Serialize(BookClassWithOrdering.GetSampleInstance());
+            Assert.That(got, Is.EqualTo(result));
+        }
+
+        [Test]
         public void WarehouseSimpleTest()
         {
             const string result =

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="SampleClasses\SelfReferencingObjects\RepetitiveReferenceIsNotLoop.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\IndirectSelfReferringObject.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\DirectSelfReferringObject.cs" />
+    <Compile Include="SampleClasses\SimpleBookClassWithOrdering.cs" />
     <Compile Include="SampleClasses\SingleLetterPropertyNames.cs" />
     <Compile Include="SampleClasses\YAXLibMetadataOverriding.cs" />
     <Compile Include="SampleClasses\CsprojParser.cs" />


### PR DESCRIPTION
 or deserialization of child elements.

I found, while doing this change, that I probably can assume the order to be the order of the properties in my classes, even when deserializing from XML where the elements there are in a different order. 

Is that right?

Anyway, I was already mostly done and this makes me feel warm and fuzzy. You see, after certain related elements are deserialized I need to do some post-processing and unless I know the dependent elements have been deserialized prior to this, I can't take action on the existence or non-existence of a value.