### PR TITLE
Ensure that attributes on properties are respected when those properties are overridden in a derived class

### DIFF
--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -129,14 +129,14 @@ namespace YAXLib
             var attrsToProcessEarlier = new HashSet<Type> {typeof (YAXCustomSerializerAttribute), typeof (YAXCollectionAttribute)};
             foreach (var attrType in attrsToProcessEarlier)
             {
-                var customSerAttrs = m_memberInfo.GetCustomAttributes(attrType, true);
+                var customSerAttrs = Attribute.GetCustomAttributes(m_memberInfo, attrType, true);
                 foreach (var attr in customSerAttrs)
                 {
                     ProcessYaxAttribute(attr);
                 }
             }
 
-            foreach (var attr in m_memberInfo.GetCustomAttributes(true))
+            foreach (var attr in Attribute.GetCustomAttributes(m_memberInfo, true))
             {
                 // no need to preces, it has been proccessed earlier
                 if (attrsToProcessEarlier.Contains(attr.GetType()))

--- a/YAXLibTests/SampleClasses/AttributeInheritance.cs
+++ b/YAXLibTests/SampleClasses/AttributeInheritance.cs
@@ -2,11 +2,32 @@
 
 namespace YAXLibTests.SampleClasses
 {
+    public class AttributeInheritanceWithPropertyOverride : AttributeInheritance
+    {
+        public override string Gender { get { return "Female"; } }  // should inherit the base's YAXSerializeAs attribute
+
+        [YAXSerializeAs("CurrentAge")]   // should override the base's YAXSerializeAs attribute
+        public override double Age
+        {
+            get { return base.Age; }
+            set { base.Age = value; }
+        }
+
+        public static new AttributeInheritanceWithPropertyOverride GetSampleInstance()
+        {
+            return new AttributeInheritanceWithPropertyOverride()
+            {
+                Name = "Sally",
+                Age = 38.7
+            };
+        }
+    }
+
     [YAXSerializeAs("Child")]
     public class AttributeInheritance : AttributeInheritanceBase
     {
         [YAXSerializeAs("TheAge")]
-        public double Age { get; set; }
+        public virtual double Age { get; set; }
 
         public static AttributeInheritance GetSampleInstance()
         {
@@ -21,7 +42,6 @@ namespace YAXLibTests.SampleClasses
         {
             return GeneralToStringProvider.GeneralToString(this);
         }
-        
     }
 
     [YAXSerializeAs("Base")]
@@ -29,5 +49,8 @@ namespace YAXLibTests.SampleClasses
     {
         [YAXSerializeAs("TheName")]
         public string Name { get; set; }
+
+        [YAXSerializeAs("TheGender")]
+        public virtual string Gender { get { return "Unknown";  } }
     }
 }

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -1794,12 +1794,27 @@ namespace YAXLibTests
 @"<Child>
   <TheAge>30.2</TheAge>
   <TheName>John</TheName>
+  <TheGender>Unknown</TheGender>
 </Child>";
             var serializer = new YAXSerializer(typeof(AttributeInheritance), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
             string got = serializer.Serialize(AttributeInheritance.GetSampleInstance());
             Assert.That(got, Is.EqualTo(result));
         }
 
+        [Test]
+        public void AttributeInheritanceWithPropertyOverrideTest()
+        {
+            const string result =
+@"<Child>
+  <TheGender>Female</TheGender>
+  <CurrentAge>38.7</CurrentAge>
+  <TheName>Sally</TheName>
+</Child>";
+            var serializer = new YAXSerializer(typeof(AttributeInheritanceWithPropertyOverride), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
+            string got = serializer.Serialize(AttributeInheritanceWithPropertyOverride.GetSampleInstance());
+            Assert.That(got, Is.EqualTo(result));
+        }
+        
         [Test]
         public void ListOfPolymorphicObjectsTest()
         {


### PR DESCRIPTION
If class A has a property with one or more YAX attributes on it, and class B (derived from A) overrode that property, YAXLib would treat the overridden property as though it had no attributes.  This patchset alters this behavior so that YAXLib applies the attributes from the base property to the overridden property, unless they too are specifically overridden.  I admit it's possible that the original behavior was intended, though I'm guessing not since (a) there were no tests for it, and (b) the original code was calling the class version of GetCustomAttributes with inherit: true, which confusingly does NOT work for properties (http://stackoverflow.com/questions/2520035/inheritance-of-custom-attributes-on-abstract-properties); the static version GetCustomAttributes does include properties when inherit is true.  

Since it's not impossible that someone was depending on the old behavior I can go back and make it an option if you'd like.