### PR TITLE
Add an option to suppress production of YAXLib metadata attributes

### DIFF
--- a/YAXLib/Enums.cs
+++ b/YAXLib/Enums.cs
@@ -79,6 +79,12 @@ namespace YAXLib
         /// Prevents serailization of properties with no setter 
         /// </summary>
         DontSerializePropertiesWithNoSetter = 4,
+
+        /// <summary>
+        /// Never add YAXLib metadata attributes (e.g., 'yaxlib:realtype') to the serialized XML (even when they would be required for deserialization.)
+        /// Useful when generating XML intended for another system's consumption.
+        /// </summary>
+        SuppressMetadataAttributes = 8
     }
 
     /// <summary>

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -243,7 +243,17 @@ namespace YAXLib
             }
         }
 
-
+        /// <summary>
+        /// Never add YAXLib metadata attributes (e.g., 'yaxlib:realtype') to the serialized XML (even when they would be required for deserialization.)
+        /// Useful when generating XML intended for another system's consumption.
+        /// </summary>
+        public bool SuppressMetadataAttributes
+        {
+            get
+            {
+                return (SerializationOption & YAXSerializationOptions.SuppressMetadataAttributes) == YAXSerializationOptions.SuppressMetadataAttributes;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether this instance wraps around a collection type.

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -599,9 +599,8 @@ namespace YAXLib
                 // and this instance of serializer did not do anything extra
                 FinalizeNewSerializer(ser, importNamespaces: true, popFromSerializationStack: false);
                 elem.Name = m_udtWrapper.Alias;
-                
-                elem.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName, obj.GetType().FullName, m_documentDefaultNamespace);
-                RegisterYaxLibNamespace();
+
+                AddMetadataAttribute(elem, m_yaxLibNamespaceUri + m_trueTypeAttrName, obj.GetType().FullName, m_documentDefaultNamespace);
                 AddNamespacesToElement(elem);
 
                 return elem;
@@ -933,10 +932,7 @@ namespace YAXLib
                                     elemToAdd.Name = XName.Get(alias, elemToAdd.Name.Namespace.NamespaceName);
                                 }
                                 else
-                                {
-                                    elemToAdd.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName, realType.FullName, m_documentDefaultNamespace);
-                                    RegisterYaxLibNamespace();
-                                }
+                                    AddMetadataAttribute(elemToAdd, m_yaxLibNamespaceUri + m_trueTypeAttrName, realType.FullName, m_documentDefaultNamespace);
                             }
 
                             if (moveDescOnly)// if only the descendants of the resulting element are going to be added ...
@@ -1008,11 +1004,6 @@ namespace YAXLib
                 RegisterNamespace(elemName.Namespace, null);
 
             return new XElement(elemName, null);
-        }
-
-        private void RegisterYaxLibNamespace()
-        {
-            RegisterNamespace(m_yaxLibNamespaceUri, m_yaxLibNamespacePrefix);
         }
 
         /// <summary>
@@ -1288,8 +1279,7 @@ namespace YAXLib
                             elemChild.Add(addedElem);
                         }
 
-                        addedElem.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName, keyObj.GetType().FullName, m_documentDefaultNamespace);
-                        RegisterYaxLibNamespace();
+                        AddMetadataAttribute(addedElem, m_yaxLibNamespaceUri + m_trueTypeAttrName, keyObj.GetType().FullName, m_documentDefaultNamespace);
                     }
                 }
 
@@ -1313,8 +1303,7 @@ namespace YAXLib
                             elemChild.Add(addedElem);
                         }
 
-                        addedElem.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName, valueObj.GetType().FullName, m_documentDefaultNamespace);
-                        RegisterYaxLibNamespace();
+                        AddMetadataAttribute(addedElem, m_yaxLibNamespaceUri + m_trueTypeAttrName, valueObj.GetType().FullName, m_documentDefaultNamespace);
                     }
                 }
 
@@ -1474,21 +1463,17 @@ namespace YAXLib
                     XElement itemElem = AddObjectToElement(elemToAdd, curElemName.OverrideNsIfEmpty(elementName.Namespace), objToAdd);
                     if (obj != null && !obj.GetType().EqualsOrIsNullableOf(colItemType))
                     {
-                        itemElem.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName, obj.GetType().FullName, m_documentDefaultNamespace);
                         if (itemElem.Parent == null) // i.e., it has been removed, e.g., because all its members have been serialized outside the element
                             elemToAdd.Add(itemElem); // return it back, or undelete this item
 
-                        RegisterYaxLibNamespace();
+                        AddMetadataAttribute(itemElem, m_yaxLibNamespaceUri + m_trueTypeAttrName, obj.GetType().FullName, m_documentDefaultNamespace);
                     }
                 }
             }
 
             int[] arrayDims = ReflectionUtils.GetArrayDimensions(elementValue);
             if (arrayDims != null && arrayDims.Length > 1)
-            {
-                elemToAdd.AddAttributeNamespaceSafe(m_yaxLibNamespaceUri + m_dimsAttrName, StringUtils.GetArrayDimsString(arrayDims), m_documentDefaultNamespace);
-                RegisterYaxLibNamespace();
-            }
+                AddMetadataAttribute(elemToAdd, m_yaxLibNamespaceUri + m_dimsAttrName, StringUtils.GetArrayDimsString(arrayDims), m_documentDefaultNamespace);
 
             return elemToAdd;
         }
@@ -2839,6 +2824,15 @@ namespace YAXLib
         private IEnumerable<MemberWrapper> GetFieldsToBeSerialized()
         {
             return GetFieldsToBeSerialized(m_udtWrapper).OrderBy(t=>t.Order);
+        }
+
+        private void AddMetadataAttribute(XElement parent, XName attrName, object attrValue, XNamespace documentDefaultNamespace)
+        {
+            if (!m_udtWrapper.SuppressMetadataAttributes)
+            {
+                parent.AddAttributeNamespaceSafe(attrName, attrValue, documentDefaultNamespace);
+                RegisterNamespace(m_yaxLibNamespaceUri, m_yaxLibNamespacePrefix);
+            }
         }
 
         /// <summary>

--- a/YAXLibTests/OverridingYAXLibMetadataTests.cs
+++ b/YAXLibTests/OverridingYAXLibMetadataTests.cs
@@ -14,18 +14,18 @@ namespace YAXLibTests
         [Test]
         public void CanOverrideAllMetadata()
         {
-            var ser = new YAXSerializer(typeof(YAXLibMetadataOverriding));
+            var ser = new YAXSerializer(typeof(YAXLibMetadataOverridingWithNamespace));
 
             ser.YaxLibNamespacePrefix = "yax";
             ser.YaxLibNamespaceUri = "http://namespace.org/yax";
             ser.DimentionsAttributeName = "dm";
             ser.RealTypeAttributeName = "type";
 
-            var sampleInstance = YAXLibMetadataOverriding.GetSampleInstance();
+            var sampleInstance = YAXLibMetadataOverridingWithNamespace.GetSampleInstance();
             string result = ser.Serialize(sampleInstance);
 
             string expected =
-@"<YAXLibMetadataOverriding xmlns:yax=""http://namespace.org/yax"" xmlns=""http://namespace.org/sample"">
+@"<YAXLibMetadataOverridingWithNamespace xmlns:yax=""http://namespace.org/yax"" xmlns=""http://namespace.org/sample"">
   <IntArray yax:dm=""2,3"">
     <Int32>1</Int32>
     <Int32>2</Int32>
@@ -35,10 +35,10 @@ namespace YAXLibTests
     <Int32>4</Int32>
   </IntArray>
   <Obj yax:type=""System.String"">Hello, World!</Obj>
-</YAXLibMetadataOverriding>";
+</YAXLibMetadataOverridingWithNamespace>";
             Assert.That(result, Is.EqualTo(expected));
             
-            var desObj = (YAXLibMetadataOverriding)ser.Deserialize(expected);
+            var desObj = (YAXLibMetadataOverridingWithNamespace)ser.Deserialize(expected);
 
             Assert.That(desObj.Obj.ToString(), Is.EqualTo(sampleInstance.Obj.ToString()));
             Assert.That(desObj.IntArray.Length, Is.EqualTo(sampleInstance.IntArray.Length));
@@ -47,19 +47,18 @@ namespace YAXLibTests
         [Test]
         public void CanUseTheDefaultNamespace()
         {
-            var ser = new YAXSerializer(typeof(YAXLibMetadataOverriding));
+            var ser = new YAXSerializer(typeof(YAXLibMetadataOverridingWithNamespace));
 
             ser.YaxLibNamespacePrefix = String.Empty;
             ser.YaxLibNamespaceUri = "http://namespace.org/sample";
             ser.DimentionsAttributeName = "dm";
             ser.RealTypeAttributeName = "type";
 
-            var sampleInstance = YAXLibMetadataOverriding.GetSampleInstance();
+            var sampleInstance = YAXLibMetadataOverridingWithNamespace.GetSampleInstance();
             string result = ser.Serialize(sampleInstance);
 
-
             string expected =
-@"<YAXLibMetadataOverriding xmlns=""http://namespace.org/sample"">
+@"<YAXLibMetadataOverridingWithNamespace xmlns=""http://namespace.org/sample"">
   <IntArray dm=""2,3"">
     <Int32>1</Int32>
     <Int32>2</Int32>
@@ -69,14 +68,59 @@ namespace YAXLibTests
     <Int32>4</Int32>
   </IntArray>
   <Obj type=""System.String"">Hello, World!</Obj>
-</YAXLibMetadataOverriding>";
+</YAXLibMetadataOverridingWithNamespace>";
             Assert.That(result, Is.EqualTo(expected));
 
-            var desObj = (YAXLibMetadataOverriding)ser.Deserialize(expected);
+            var desObj = (YAXLibMetadataOverridingWithNamespace)ser.Deserialize(expected);
 
             Assert.That(desObj.Obj.ToString(), Is.EqualTo(sampleInstance.Obj.ToString()));
             Assert.That(desObj.IntArray.Length, Is.EqualTo(sampleInstance.IntArray.Length));
         }
 
+        [Test]
+        public void CanSuppressMetadata()
+        {
+            var ser = new YAXSerializer(typeof(YAXLibMetadataOverriding), YAXSerializationOptions.SuppressMetadataAttributes);
+
+            var sampleInstance = YAXLibMetadataOverriding.GetSampleInstance();
+            string result = ser.Serialize(sampleInstance);
+
+            string expected =
+    @"<YAXLibMetadataOverriding>
+  <IntArray>
+    <Int32>1</Int32>
+    <Int32>2</Int32>
+    <Int32>3</Int32>
+    <Int32>2</Int32>
+    <Int32>3</Int32>
+    <Int32>4</Int32>
+  </IntArray>
+  <Obj>Hello, World!</Obj>
+</YAXLibMetadataOverriding>";
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void CanSuppressMetadataButUseCustomNamespace()
+        {
+            var ser = new YAXSerializer(typeof(YAXLibMetadataOverridingWithNamespace), YAXSerializationOptions.SuppressMetadataAttributes);
+
+            var sampleInstance = YAXLibMetadataOverridingWithNamespace.GetSampleInstance();
+            string result = ser.Serialize(sampleInstance);
+
+            string expected =
+    @"<YAXLibMetadataOverridingWithNamespace xmlns=""http://namespace.org/sample"">
+  <IntArray>
+    <Int32>1</Int32>
+    <Int32>2</Int32>
+    <Int32>3</Int32>
+    <Int32>2</Int32>
+    <Int32>3</Int32>
+    <Int32>4</Int32>
+  </IntArray>
+  <Obj>Hello, World!</Obj>
+</YAXLibMetadataOverridingWithNamespace>";
+            Assert.That(result, Is.EqualTo(expected));
+        }
     }
 }

--- a/YAXLibTests/SampleClasses/YAXLibMetadataOverriding.cs
+++ b/YAXLibTests/SampleClasses/YAXLibMetadataOverriding.cs
@@ -7,7 +7,6 @@ using YAXLib;
 namespace YAXLibTests.SampleClasses
 {
     [ShowInDemoApplication]
-    [YAXNamespace("http://namespace.org/sample")]
     public class YAXLibMetadataOverriding
     {
         public int[,] IntArray { get; set; }
@@ -22,18 +21,32 @@ namespace YAXLibTests.SampleClasses
 
         public static YAXLibMetadataOverriding GetSampleInstance()
         {
-            int[,] intArray = new int[2,3];
+            YAXLibMetadataOverriding instance = new YAXLibMetadataOverriding();
+            instance.SetSampleData();
+            return instance;
+        }
+
+        protected void SetSampleData()
+        {
+            IntArray = new int[2, 3];
 
             for (int i = 0; i < 2; i++)
                 for (int j = 0; j < 3; j++)
-                    intArray[i, j] = i + j + 1;
+                    IntArray[i, j] = i + j + 1;
 
+            Obj = "Hello, World!";
+        }
+    }
 
-            return new YAXLibMetadataOverriding()
-            {
-                IntArray = intArray,
-                Obj = "Hello, World!"
-            };
+    [ShowInDemoApplication]
+    [YAXNamespace("http://namespace.org/sample")]
+    public class YAXLibMetadataOverridingWithNamespace : YAXLibMetadataOverriding
+    {
+        public static new YAXLibMetadataOverridingWithNamespace GetSampleInstance()
+        {
+            YAXLibMetadataOverridingWithNamespace instance = new YAXLibMetadataOverridingWithNamespace();
+            instance.SetSampleData();
+            return instance;
         }
     }
 }


### PR DESCRIPTION
When using YAXLib to generate XML for the consumption of other systems, the metdata attributes it adds under some circumstances to facilitate later deserialization (e.g., 'yaxlib:realtype') are unnecessary and may confuse the target system.  This changeset adds a serialization option (SuppressMetadataAttributes) to prevent the creation of said attributes.  Obviously enabling this option could make later deserialization via YAXLib impossible.