### PR TITLE
Make ParseDateTimeTimeZoneSafe culture aware

### DIFF
--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -359,21 +359,11 @@ namespace YAXLib
         public static DateTime ParseDateTimeTimeZoneSafe(string str, IFormatProvider formatProvider)
         {
             DateTimeOffset dto;
-            if (!DateTimeOffset.TryParse(str, out dto))
+            if (!DateTimeOffset.TryParse(str, formatProvider, System.Globalization.DateTimeStyles.None, out dto))
             {
                 return DateTime.MinValue;
             }
-
-            if (dto.Offset == TimeSpan.Zero)
-            {
-                return dto.UtcDateTime;
-            }
-            else
-            {
-                return dto.DateTime;
-            }
+            return dto.Offset == TimeSpan.Zero ? dto.UtcDateTime : dto.DateTime;
         }
-
-
     }
 }

--- a/YAXLibTests/SampleClasses/CultureSample.cs
+++ b/YAXLibTests/SampleClasses/CultureSample.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using YAXLib;
 
 namespace YAXLibTests.SampleClasses
 {
     [YAXComment("This class contains fields that are vulnerable to culture changes!")]
-    public class CultureSample
+    public class CultureSample : IComparable<CultureSample>
     {
         public double Number1 { get; set; }
 
@@ -43,6 +43,36 @@ namespace YAXLibTests.SampleClasses
         public override string ToString()
         {
             return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public int CompareTo(object obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(CultureSample other)
+        {
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
+            var numbersComparison = Numbers.Length.CompareTo(other.Numbers.Length);
+            if (numbersComparison != 0) return numbersComparison;
+            for (var i = 0; i < Numbers.Length; i++)
+            {
+                numbersComparison = Numbers[i].CompareTo(other.Numbers[i]);
+                if (numbersComparison != 0) return numbersComparison;
+            }
+            var number1Comparison = Number1.CompareTo(other.Number1);
+            if (number1Comparison != 0) return number1Comparison;
+            var number2Comparison = Number2.CompareTo(other.Number2);
+            if (number2Comparison != 0) return number2Comparison;
+            var number3Comparison = Number3.CompareTo(other.Number3);
+            if (number3Comparison != 0) return number3Comparison;
+            var dec1Comparison = Dec1.CompareTo(other.Dec1);
+            if (dec1Comparison != 0) return dec1Comparison;
+            var dec2Comparison = Dec2.CompareTo(other.Dec2);
+            if (dec2Comparison != 0) return dec2Comparison;
+            var date1Comparison = Date1.CompareTo(other.Date1);
+            return date1Comparison != 0 ? date1Comparison : Date2.CompareTo(other.Date2);
         }
     }
 }

--- a/YAXLibTests/SampleClasses/CultureSample.cs
+++ b/YAXLibTests/SampleClasses/CultureSample.cs
@@ -1,11 +1,42 @@
-using System;
+﻿using System;
+using System.Linq;
 using YAXLib;
 
 namespace YAXLibTests.SampleClasses
 {
     [YAXComment("This class contains fields that are vulnerable to culture changes!")]
-    public class CultureSample : IComparable<CultureSample>
+    public class CultureSample
     {
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((CultureSample) obj);
+        }
+
+        protected bool Equals(CultureSample other)
+        {
+            if (Numbers.Where((t, i) => !t.Equals(other.Numbers[i])).Any()) { return false; }
+            return Number1.Equals(other.Number1) && Number2.Equals(other.Number2) && Number3.Equals(other.Number3) && Dec1 == other.Dec1 && Dec2 == other.Dec2 && Date1.Equals(other.Date1) && Date2.Equals(other.Date2);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Number1.GetHashCode();
+                hashCode = (hashCode * 397) ^ Number2.GetHashCode();
+                hashCode = (hashCode * 397) ^ Number3.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Numbers?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Dec1.GetHashCode();
+                hashCode = (hashCode * 397) ^ Dec2.GetHashCode();
+                hashCode = (hashCode * 397) ^ Date1.GetHashCode();
+                hashCode = (hashCode * 397) ^ Date2.GetHashCode();
+                return hashCode;
+            }
+        }
+
         public double Number1 { get; set; }
 
         [YAXAttributeForClass]
@@ -43,31 +74,6 @@ namespace YAXLibTests.SampleClasses
         public override string ToString()
         {
             return GeneralToStringProvider.GeneralToString(this);
-        }
-
-        public int CompareTo(CultureSample other)
-        {
-            if (ReferenceEquals(this, other)) return 0;
-            if (ReferenceEquals(null, other)) return 1;
-            var numbersComparison = Numbers.Length.CompareTo(other.Numbers.Length);
-            if (numbersComparison != 0) return numbersComparison;
-            for (var i = 0; i < Numbers.Length; i++)
-            {
-                numbersComparison = Numbers[i].CompareTo(other.Numbers[i]);
-                if (numbersComparison != 0) return numbersComparison;
-            }
-            var number1Comparison = Number1.CompareTo(other.Number1);
-            if (number1Comparison != 0) return number1Comparison;
-            var number2Comparison = Number2.CompareTo(other.Number2);
-            if (number2Comparison != 0) return number2Comparison;
-            var number3Comparison = Number3.CompareTo(other.Number3);
-            if (number3Comparison != 0) return number3Comparison;
-            var dec1Comparison = Dec1.CompareTo(other.Dec1);
-            if (dec1Comparison != 0) return dec1Comparison;
-            var dec2Comparison = Dec2.CompareTo(other.Dec2);
-            if (dec2Comparison != 0) return dec2Comparison;
-            var date1Comparison = Date1.CompareTo(other.Date1);
-            return date1Comparison != 0 ? date1Comparison : Date2.CompareTo(other.Date2);
         }
     }
 }

--- a/YAXLibTests/SampleClasses/CultureSample.cs
+++ b/YAXLibTests/SampleClasses/CultureSample.cs
@@ -45,11 +45,6 @@ namespace YAXLibTests.SampleClasses
             return GeneralToStringProvider.GeneralToString(this);
         }
 
-        public int CompareTo(object obj)
-        {
-            throw new NotImplementedException();
-        }
-
         public int CompareTo(CultureSample other)
         {
             if (ReferenceEquals(this, other)) return 0;

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2009 - 2010 Sina Iravanian - <sina@sinairv.com>
+// Copyright 2009 - 2010 Sina Iravanian - <sina@sinairv.com>
 //
 // This source file(s) may be redistributed, altered and customized
 // by any means PROVIDING the authors name and all copyright

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -116,6 +116,7 @@ namespace YAXLibTests
         [Test]
         public void CultureChangeTest()
         {
+            // Save current culture
             var curCulture = CultureInfo.CurrentCulture;
 #if FXCORE
             CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
@@ -123,40 +124,48 @@ namespace YAXLibTests
             Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
 #endif
             var serializer = new YAXSerializer(typeof(CultureSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            string frResult = serializer.Serialize(CultureSample.GetSampleInstance());
+            var frSerResult = serializer.Serialize(CultureSample.GetSampleInstance());
 
 #if FXCORE
             CultureInfo.CurrentCulture = new CultureInfo("fa-IR");
 #else
             Thread.CurrentThread.CurrentCulture = new CultureInfo("fa-IR");
 #endif
+            var frDesResult = serializer.Deserialize(frSerResult) as CultureSample;
 
             serializer = new YAXSerializer(typeof(CultureSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            string faResult = serializer.Serialize(CultureSample.GetSampleInstance());
+            var faSerResult = serializer.Serialize(CultureSample.GetSampleInstance());
 #if FXCORE
             CultureInfo.CurrentCulture = new CultureInfo("de-DE");
 #else
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
 #endif
+            var faDesResult = serializer.Deserialize(faSerResult) as CultureSample;
 
             serializer = new YAXSerializer(typeof(CultureSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            string deResult = serializer.Serialize(CultureSample.GetSampleInstance());
+            var deSerResult = serializer.Serialize(CultureSample.GetSampleInstance());
 #if FXCORE
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
 #else
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 #endif
+            var deDesResult = serializer.Deserialize(deSerResult) as CultureSample;
 
             serializer = new YAXSerializer(typeof(CultureSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            string usResult = serializer.Serialize(CultureSample.GetSampleInstance());
+            var usSerResult = serializer.Serialize(CultureSample.GetSampleInstance());
+            
+            // Restore current culture
 #if FXCORE
             CultureInfo.CurrentCulture = curCulture;
 #else
             Thread.CurrentThread.CurrentCulture = curCulture;
 #endif
-            Assert.That(faResult, Is.EqualTo(frResult), "Comparing FR and FA");
-            Assert.That(deResult, Is.EqualTo(faResult), "Comparing FA and DE");
-            Assert.That(usResult, Is.EqualTo(deResult), "Comparing DE and US");
+            var usDesResult = serializer.Deserialize(usSerResult) as CultureSample;
+
+            // serialization results
+            Assert.That(faSerResult, Is.EqualTo(frSerResult), "Comparing serialized FA and FR");
+            Assert.That(deSerResult, Is.EqualTo(faSerResult), "Comparing serialized DE and FA");
+            Assert.That(usSerResult, Is.EqualTo(deSerResult), "Comparing serialized US and DE");
 
             const string expected =
 @"<!-- This class contains fields that are vulnerable to culture changes! -->
@@ -171,8 +180,13 @@ namespace YAXLibTests
   <Dec1>192389183919123.18232131</Dec1>
   <Date1>10/11/2010 18:20:30</Date1>
 </CultureSample>";
+            Assert.That(expected, Is.EqualTo(usSerResult), "Checking US is as expected!");
 
-            Assert.That(expected, Is.EqualTo(usResult), "Checking US is as expected!");
+            // deserialization results
+            Assert.AreEqual(0, faDesResult?.CompareTo(frDesResult), "Comparing deserialized FA and FR");
+            Assert.AreEqual(0, deDesResult?.CompareTo(faDesResult), "Comparing deserialized DE and FA");
+            Assert.AreEqual(0, usDesResult?.CompareTo(deDesResult), "Comparing deserialized US and DE");
+            Assert.AreEqual(0, usDesResult?.CompareTo(CultureSample.GetSampleInstance()), "Comparing deserialized US and new instance");
         }
 
         [Test]

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -116,7 +116,7 @@ namespace YAXLibTests
         [TestCase("", "fr-FR")]
         [TestCase("fr-FR", "en-US")]
         [TestCase("de-DE", "")]
-        [TestCase("fr-IA", "en-US")]
+        [TestCase("fa-IR", "en-US")]
         [TestCase("en-US", "")]
         public void CultureChangeTest(string cultName1, string cultName2)
         {


### PR DESCRIPTION
Fixes issue https://github.com/sinairv/YAXLib/issues/35
As @gitgordon pointed out, the public static method ```ParseDateTimeTimeZoneSafe``` does not use the argument ```IFormatProvider```, and so the culture which ```DateTimeOffset.TryParse``` is expected to use is not set by YAXLib code. Depending on the system culture or the culture set by any code for the current thread it might work or fail.
With NUnit3 tests the current culture was set ```System.Globalization.CultureInfo.InvariantCulture``` which was the reason for the tests to succeed.
This fix seems to be kind of urgent IMHO.
