### PR TITLE
Fix unstable DesNonGenericCollectionsSampleTest test with equals()

### DIFF
--- a/YAXLibTests/DeserializationTest.cs
+++ b/YAXLibTests/DeserializationTest.cs
@@ -40,15 +40,34 @@ namespace YAXLibTests
             PerformTestAndReturn(obj);
         }
 
+        /// <summary>
+        /// Perform test by using .Equals. Equals should be well implemented for <paramref name="obj"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        private void PerformTestWithEquals(object obj)
+        {
+            object gottonObject;
+            var serializer = SerializeDeserialize(obj, out gottonObject);
+            Assert.AreEqual(0, serializer.ParsingErrors.Count);
+            Assert.AreEqual(obj, gottonObject);
+        }
+
         private object GetTheTwoStringsAndReturn(object obj, out string originalString, out string gottonString, out int errorCounts)
         {
             originalString = GeneralToStringProvider.GeneralToString(obj);
-            var serializer = new YAXSerializer(obj.GetType(), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            var serResult = serializer.Serialize(obj);
-            object gottonObject = serializer.Deserialize(serResult);
+            object gottonObject;
+            var serializer = SerializeDeserialize(obj, out gottonObject);
             errorCounts = serializer.ParsingErrors.Count;
             gottonString = GeneralToStringProvider.GeneralToString(gottonObject);
             return gottonObject;
+        }
+
+        private static YAXSerializer SerializeDeserialize(object obj, out object gottonObject)
+        {
+            var serializer = new YAXSerializer(obj.GetType(), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
+            var serResult = serializer.Serialize(obj);
+            gottonObject = serializer.Deserialize(serResult);
+            return serializer;
         }
 
         private object PerformTestAndReturn(object obj)
@@ -175,7 +194,7 @@ namespace YAXLibTests
             Guid g3 = Guid.NewGuid();
             Guid g4 = Guid.NewGuid();
 
-            object obj = GUIDTest.GetSampleInstance(g1,g2,g3,g4);
+            object obj = GUIDTest.GetSampleInstance(g1, g2, g3, g4);
             PerformTest(obj);
         }
 
@@ -185,7 +204,7 @@ namespace YAXLibTests
             const string xml = @"<NullableSample2 />";
             YAXSerializer serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow);
             NullableSample2 got = (NullableSample2)serializer.Deserialize(xml);
-            
+
             Assert.That(got, Is.Not.Null);
             Assert.That(got.Boolean, Is.Null);
             Assert.That(got.DateTime, Is.Null);
@@ -325,7 +344,7 @@ namespace YAXLibTests
         public void DesNonGenericCollectionsSampleTest()
         {
             object obj = NonGenericCollectionsSample.GetSampleInstance();
-            PerformTest(obj);
+            PerformTestWithEquals(obj);
         }
 
         [Test]
@@ -496,7 +515,7 @@ namespace YAXLibTests
         public void AttributeForKeyInDictionaryPropertyTest()
         {
             var container = DictionaryContainerSample.GetSampleInstance();
-            
+
             var ser = new YAXSerializer(typeof(DictionaryContainerSample));
 
             string input = ser.Serialize(container);
@@ -522,7 +541,7 @@ namespace YAXLibTests
             var deserializedInstance = (DictionarySample)ser.Deserialize(input);
 
             Assert.That(deserializedInstance, Is.Not.Null);
-            Assert.IsTrue(deserializedInstance.Count  == inst.Count,
+            Assert.IsTrue(deserializedInstance.Count == inst.Count,
                           "Expected Count: {0}. Actual Count: {1}",
                           inst.Count,
                           deserializedInstance.Count);
@@ -582,7 +601,7 @@ namespace YAXLibTests
         {
             var inst = IndirectSelfReferringObject.GetSampleInstanceWithLoop();
 
-            var ser = new YAXSerializer(typeof(IndirectSelfReferringObject), 
+            var ser = new YAXSerializer(typeof(IndirectSelfReferringObject),
                 YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Error);
 
             string input = ser.Serialize(inst);
@@ -685,7 +704,7 @@ namespace YAXLibTests
                     new BaseItem { Data = "Some Data" }
                 }
             };
-            string result = ser.Serialize(container); 
+            string result = ser.Serialize(container);
             var deserialzedInstance = ser.Deserialize(result) as BaseContainer;
 
             Assert.That(deserialzedInstance.Items[0].Data, Is.EqualTo("Some Data"));

--- a/YAXLibTests/EqualsHelpers.cs
+++ b/YAXLibTests/EqualsHelpers.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace YAXLibTests
+{
+    /// <summary>
+    /// Helpers for .Equals
+    /// </summary>
+    internal class EqualsHelpers
+    {
+        /// <summary>
+        /// Equals ICollection, should be in same order
+        /// </summary>
+        /// <param name="me"></param>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public static bool CollectionEquals(ICollection me, ICollection other)
+        {
+            if (me == null)
+            {
+                return other == null;
+            }
+            if (other == null)
+            {
+                return false;
+            }
+            if (me.Count != other.Count)
+            {
+                return false;
+            }
+
+            return me.Cast<object>().SequenceEqual(other.Cast<object>());
+        }
+
+        /// <summary>
+        /// Equals IDictionary, order doesn't matter
+        /// </summary>
+        public static bool DictionaryEquals(IDictionary me, IDictionary other)
+        {
+            if (me == null)
+            {
+                return other == null;
+            }
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (me.Count != other.Count)
+            {
+                return false;
+            }
+            
+            foreach (var k in me.Keys)
+            {
+                if (!other.Contains(k))
+                {
+                    return false;
+                }
+                var val1 = me[k];
+                var val2 = other[k];
+                if (!Equals(val1, val2))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var k in other.Keys)
+            {
+                if (!me.Contains(k))
+                {
+                    return false;
+                }
+             
+            }
+            return true;
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/MoreComplexBook2.cs
+++ b/YAXLibTests/SampleClasses/MoreComplexBook2.cs
@@ -15,6 +15,36 @@ namespace YAXLibTests.SampleClasses
         [YAXSerializeAs("Author's Age")]
         [YAXElementFor("../Something/Or/Another")]
         public int Age { get; set; }
+
+        #region Equality members
+
+        protected bool Equals(Author other)
+        {
+            return string.Equals(Name, other.Name) && Age == other.Age;
+        }
+
+        /// <summary>Determines whether the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />.</summary>
+        /// <returns>true if the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />; otherwise, false.</returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Author) obj);
+        }
+
+        /// <summary>Serves as a hash function for a particular type. </summary>
+        /// <returns>A hash code for the current <see cref="T:System.Object" />.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ Age;
+            }
+        }
+
+        #endregion
     }
 
     [ShowInDemoApplication]

--- a/YAXLibTests/SampleClasses/NonGenericCollectionsSample.cs
+++ b/YAXLibTests/SampleClasses/NonGenericCollectionsSample.cs
@@ -81,7 +81,53 @@ namespace YAXLibTests.SampleClasses
                 TheStack = stack,
                 TheSortedList = sortedList
             };
+
+
+
         }
 
+        #region Equality members
+
+        protected bool Equals(NonGenericCollectionsSample other)
+        {
+            return EqualsHelpers.CollectionEquals(ObjList, other.ObjList) 
+                && EqualsHelpers.CollectionEquals(TheArrayList, other.TheArrayList) 
+                && EqualsHelpers.DictionaryEquals(TheHashtable, other.TheHashtable)
+                && EqualsHelpers.CollectionEquals(TheQueue, other.TheQueue)
+                && EqualsHelpers.CollectionEquals(TheStack, other.TheStack) 
+                && EqualsHelpers.DictionaryEquals(TheSortedList, other.TheSortedList)
+                && EqualsHelpers.CollectionEquals(TheBitArray, other.TheBitArray);
+        }
+
+
+        /// <summary>Determines whether the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />.</summary>
+        /// <returns>true if the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />; otherwise, false.</returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NonGenericCollectionsSample) obj);
+        }
+
+        /// <summary>Serves as a hash function for a particular type. </summary>
+        /// <returns>A hash code for the current <see cref="T:System.Object" />.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (ObjList != null ? ObjList.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheArrayList != null ? TheArrayList.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheHashtable != null ? TheHashtable.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheQueue != null ? TheQueue.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheStack != null ? TheStack.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheSortedList != null ? TheSortedList.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (TheBitArray != null ? TheBitArray.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        #endregion
     }
 }

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeserializationTest.cs" />
+    <Compile Include="EqualsHelpers.cs" />
     <Compile Include="GeneralToString.cs" />
     <Compile Include="KnownTypeTests.cs" />
     <Compile Include="NamespaceTest.cs" />


### PR DESCRIPTION
Partly generated .Equals and test with .Equals

fixes https://github.com/sinairv/YAXLib/issues/61