### PR TITLE
Unexpected nullref

### DIFF
--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -358,7 +358,7 @@ namespace YAXLib
         {
             XElement elem = CreateElement(baseElement, location, elemName);
             if (elem != null)
-                elem.SetValue(elemValue);
+                elem.SetValue(elemValue ?? string.Empty);
             return elem;
         }
 

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -954,7 +954,7 @@ namespace YAXLib
                                 {
                                     if (ReflectionUtils.IsBasicType(member.MemberType))
                                     {
-                                        existingElem.SetValue(elementValue);
+                                        existingElem.SetValue(elementValue ?? string.Empty);
                                     }
                                     else
                                     {

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using NUnit.Framework;
+using YAXLib;
+using YAXLibTests.SampleClasses;
+
+namespace YAXLibTests
+{
+    class ExceptionTests
+    {
+        [Test]
+        public void YAXAttributeAlreadyExistsExceptionTest()
+        {
+            var ex = Assert.Throws<YAXAttributeAlreadyExistsException>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(ClassWithDuplicateYaxAttribute), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error);
+                serializer.Serialize(ClassWithDuplicateYaxAttribute.GetSampleInstance());
+            });
+
+            Assert.AreEqual("test", ex.AttrName);
+            StringAssert.Contains("'test'", ex.Message);
+        }
+
+        [Test]
+        public void YAXBadlyFormedXMLTest()
+        {
+            var ex = Assert.Throws<YAXBadlyFormedXML>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error);
+                serializer.Deserialize("some garbage!");
+            });
+
+            StringAssert.Contains("not properly formatted", ex.Message);
+        }
+
+        [Test]
+        public void YAXObjectTypeMismatchExceptionTest()
+        {
+            var ex = Assert.Throws<YAXObjectTypeMismatch>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowErrorsOnly);
+                serializer.Serialize(new ClassWithDuplicateYaxAttribute());
+            });
+
+            Assert.AreEqual(typeof(Book), ex.ExpectedType);
+            Assert.AreEqual(typeof(ClassWithDuplicateYaxAttribute), ex.ReceivedType);
+            StringAssert.Contains("'Book'", ex.Message);
+            StringAssert.Contains("'ClassWithDuplicateYaxAttribute'", ex.Message);
+        }
+
+    }
+}

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -47,5 +47,15 @@ namespace YAXLibTests
             StringAssert.Contains("'ClassWithDuplicateYaxAttribute'", ex.Message);
         }
 
+        [Test]
+        public void YAXAttributeAlreadyExistsExceptionTest2()
+        {
+            Assert.Throws<YAXAttributeAlreadyExistsException>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(ClassWithDuplicateYaxAttribute2), YAXExceptionHandlingPolicies.ThrowErrorsOnly);
+                serializer.Serialize(new ClassWithDuplicateYaxAttribute2());
+            });
+        }
+
     }
 }

--- a/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
+++ b/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
@@ -30,9 +30,11 @@ namespace YAXLibTests.SampleClasses
     class ClassWithDuplicateYaxAttribute2
     {
         [YAXSerializeAs("test")]
+        [YAXAttributeForClass]
         public string Test1 { get; set; }
 
         [YAXSerializeAs("test")]
+        [YAXAttributeForClass]
         public string Test2 { get; set; }
 
       

--- a/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
+++ b/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
@@ -25,4 +25,16 @@ namespace YAXLibTests.SampleClasses
             };
         }
     }
+
+
+    class ClassWithDuplicateYaxAttribute2
+    {
+        [YAXSerializeAs("test")]
+        public string Test1 { get; set; }
+
+        [YAXSerializeAs("test")]
+        public string Test2 { get; set; }
+
+      
+    }
 }

--- a/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
+++ b/YAXLibTests/SampleClasses/ClassWithDuplicateYaxAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses
+{
+    class ClassWithDuplicateYaxAttribute
+    {
+        [YAXAttributeForClass]
+        [YAXSerializeAs("test")]
+        public string Test1 { get; set; }
+
+        [YAXAttributeForClass]
+        [YAXSerializeAs("test")]
+        public string Test2 { get; set; }
+
+        public static ClassWithDuplicateYaxAttribute GetSampleInstance()
+        {
+            return new ClassWithDuplicateYaxAttribute()
+            {
+                Test1 = "test1",
+                Test2 = "test2"
+            };
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/ClassWithDuplicateYaxValue.cs
+++ b/YAXLibTests/SampleClasses/ClassWithDuplicateYaxValue.cs
@@ -1,0 +1,39 @@
+﻿using YAXLib;
+
+namespace YAXLibTests.SampleClasses
+{
+    class ClassWithDuplicateYaxValue
+    {
+        [YAXSerializableField]
+        [YAXValueForClass]
+        public string Value1 { get; set; }
+
+        [YAXSerializableField]
+        [YAXValueForClass]
+        public string Value2 { get; set; }
+
+        public static ClassWithDuplicateYaxValue GetSampleInstance()
+        {
+            return new ClassWithDuplicateYaxValue()
+            {
+                Value1 = "lorum ipsum",
+                Value2 = "lorum oopsum"
+            };
+        }
+    }
+
+    class ClassWithInvalidFormat
+    {
+        [YAXSerializableField]
+        [YAXFormat("fancyFormat")]
+        public int Value1 { get; set; }
+
+        public static ClassWithInvalidFormat GetSampleInstance()
+        {
+            return new ClassWithInvalidFormat()
+            {
+                Value1 = 500,
+            };
+        }
+    }
+}

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="DeserializationTest.cs" />
     <Compile Include="EqualsHelpers.cs" />
+    <Compile Include="ExceptionTests.cs" />
     <Compile Include="GeneralToString.cs" />
     <Compile Include="KnownTypeTests.cs" />
     <Compile Include="NamespaceTest.cs" />
@@ -65,6 +66,8 @@
     <Compile Include="SampleClasses\AudioSample.cs" />
     <Compile Include="SampleClasses\BookClassTestingSerializeAsValue.cs" />
     <Compile Include="SampleClasses\ClassContainingXElement.cs" />
+    <Compile Include="SampleClasses\ClassWithDuplicateYaxAttribute.cs" />
+    <Compile Include="SampleClasses\ClassWithDuplicateYaxValue.cs" />
     <Compile Include="SampleClasses\Code4PublicTheme.cs" />
     <Compile Include="SampleClasses\CollectionOfInterfacesSample.cs" />
     <Compile Include="SampleClasses\CollectionSeriallyAsAttribute.cs" />


### PR DESCRIPTION
This test is throwing `ArgumentNullException` - I didn't expected that.

```
Test Name:	YAXAttributeAlreadyExistsExceptionTest2

Result StackTrace:	at YAXLibTests.ExceptionTests.YAXAttributeAlreadyExistsExceptionTest2() in YAXLibTests\ExceptionTests.cs:line 53
Result Message:	
Expected: <YAXLib.YAXAttributeAlreadyExistsException>
  But was:  <System.ArgumentNullException: Value cannot be null.
Parameter name: value
   at System.Xml.Linq.XElement.SetValue(Object value)
   at YAXLib.YAXSerializer.SerializeBase(Object obj, XName className) in YAXLib\YAXSerializer.cs:line 957
   at YAXLib.YAXSerializer.SerializeBase(Object obj) in YAXLib\YAXSerializer.cs:line 611
   at YAXLib.YAXSerializer.SerializeXDocument(Object obj) in YAXLib\YAXSerializer.cs:line 539
   at YAXLib.YAXSerializer.Serialize(Object obj) in YAXLib\YAXSerializer.cs:line 349
   at YAXLibTests.ExceptionTests.<>c.<YAXAttributeAlreadyExistsExceptionTest2>b__3_0() in YAXLibTests\ExceptionTests.cs:line 56
   at NUnit.Framework.Assert.Throws(IResolveConstraint expression, TestDelegate code, String message, Object[] args)>

```

is this a bug?