### PR TITLE
Exception line numbers

### DIFF
--- a/DemoApplication/DemoApplication.csproj
+++ b/DemoApplication/DemoApplication.csproj
@@ -43,6 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/YAXLib/Enums.cs
+++ b/YAXLib/Enums.cs
@@ -84,7 +84,13 @@ namespace YAXLib
         /// Never add YAXLib metadata attributes (e.g., 'yaxlib:realtype') to the serialized XML (even when they would be required for deserialization.)
         /// Useful when generating XML intended for another system's consumption.
         /// </summary>
-        SuppressMetadataAttributes = 8
+        SuppressMetadataAttributes = 8,
+
+        /// <summary>
+        /// Provides line number and position (where available) in deserialization exceptions.
+        /// Enabling this may have a performance impact
+        /// </summary> 
+        DisplayLineInfoInExceptions = 16
     }
 
     /// <summary>

--- a/YAXLib/KnownTypes.cs
+++ b/YAXLib/KnownTypes.cs
@@ -219,7 +219,7 @@ namespace YAXLib
             var elemHeight = elem.Element(this.GetXName("Height", overridingNamespace));
 
             if (elemHeight == null || elemWidth == null || elemTop == null || elemLeft == null)
-                throw new YAXElementMissingException(elem.Name + ":[Left|Top|Width|Height]");
+                throw new YAXElementMissingException(elem.Name + ":[Left|Top|Width|Height]", elem);
 
             return Activator.CreateInstance(Type,  
                         Int32.Parse(elemLeft.Value),
@@ -452,7 +452,7 @@ namespace YAXLib
                 TimeSpan timeSpanResult;
                 if (!TimeSpan.TryParse(strTimeSpanString, out timeSpanResult))
                 {
-                    throw new YAXBadlyFormedInput(elem.Name.ToString(), elem.Value);
+                    throw new YAXBadlyFormedInput(elem.Name.ToString(), elem.Value, elem);
                 }
                 return timeSpanResult;
             }
@@ -462,7 +462,7 @@ namespace YAXLib
                 long ticks;
                 if (!Int64.TryParse(strTicks, out ticks))
                 {
-                    throw new YAXBadlyFormedInput("Ticks", elemTicks.Value);
+                    throw new YAXBadlyFormedInput("Ticks", elemTicks.Value, elemTicks);
                 }
                 return new TimeSpan(ticks);
             }

--- a/YAXLib/YAXExceptions.cs
+++ b/YAXLib/YAXExceptions.cs
@@ -75,11 +75,12 @@ namespace YAXLib
         /// </summary>
         public int LinePosition { get; private set; }
 
-
-        /// <inheritdoc />
-        public override string Message => HasLineInfo
-            ? string.Format(CultureInfo.CurrentCulture, "Error at line {0}, position {1}", LineNumber, LinePosition)
-            : "Error";
+        /// <summary>
+        /// Position string for use in error message
+        /// </summary>
+        protected string LineInfoMessage => HasLineInfo
+            ? string.Format(CultureInfo.CurrentCulture, " (line {0}, position {1})", LineNumber, LinePosition)
+            : string.Empty;
     }
 
     /// <summary>
@@ -214,7 +215,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "{0}: No attributes with this name found: '{1}'.", base.Message, this.AttributeName);
+                return String.Format(CultureInfo.CurrentCulture, "No attributes with this name found: '{0}'{1}.", this.AttributeName, this.LineInfoMessage);
             }
         }
 
@@ -261,7 +262,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "{0}: Element with the given name does not contain text values: '{1}'.", base.Message, this.ElementName);
+                return String.Format(CultureInfo.CurrentCulture, "Element with the given name does not contain text values: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -309,7 +310,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "{0}: Element with the given name already has value: '{1}'.", base.Message, this.ElementName);
+                return String.Format(CultureInfo.CurrentCulture, "Element with the given name already has value: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -357,7 +358,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "{0}: No elements with this name found: '{1}'.", base.Message, this.ElementName);
+                return String.Format(CultureInfo.CurrentCulture, "No elements with this name found: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -415,10 +416,10 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "{0}: The format of the value specified for the property '{1}' is not proper: '{2}'.",
-                    base.Message,
+                    "The format of the value specified for the property '{0}' is not proper: '{1}'{2}.",                    
                     this.ElementName,
-                    this.BadInput);
+                    this.BadInput, 
+                    this.LineInfoMessage);
             }
         }
 
@@ -466,7 +467,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "{0}: Could not assign to the property '{1}'.", base.Message, this.PropertyName);
+                return String.Format(CultureInfo.CurrentCulture, "Could not assign to the property '{0}'{1}.", this.PropertyName, this.LineInfoMessage);
             }
         }
 
@@ -523,10 +524,10 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "{0}: Could not add object ('{1}') to the collection ('{2}').",
-                    base.Message,
+                    "Could not add object ('{0}') to the collection ('{1}'){2}.",                    
                     this.ObjectToAdd,
-                    this.PropertyName);
+                    this.PropertyName, 
+                    this.LineInfoMessage);
             }
         }
 
@@ -583,10 +584,10 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "{0}: Could not assign the default value specified ('{1}') for the property '{2}'.",
-                    base.Message,
+                    "Could not assign the default value specified ('{0}') for the property '{1}'{2}.",                    
                     this.TheDefaultValue,
-                    this.PropertyName);
+                    this.PropertyName, 
+                    this.LineInfoMessage);
             }
         }
 

--- a/YAXLib/YAXExceptions.cs
+++ b/YAXLib/YAXExceptions.cs
@@ -187,6 +187,15 @@ namespace YAXLib
         /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
         /// </summary>
         /// <param name="attrName">Name of the attribute.</param>
+        public YAXAttributeMissingException(string attrName) :
+            this(attrName, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
+        /// </summary>
+        /// <param name="attrName">Name of the attribute.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
         public YAXAttributeMissingException(string attrName, IXmlLineInfo lineInfo) : 
             base(lineInfo)
@@ -229,6 +238,15 @@ namespace YAXLib
     public class YAXElementValueMissingException : YAXDeserializationException
     {
         #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
+        /// </summary>
+        /// <param name="elementName">Name of the element.</param>
+        public YAXElementValueMissingException(string elementName) :
+            this(elementName, null)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
@@ -282,6 +300,15 @@ namespace YAXLib
         /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
         /// </summary>
         /// <param name="elementName">Name of the element.</param>
+        public YAXElementValueAlreadyExistsException(string elementName) :
+            this(elementName, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXAttributeMissingException"/> class.
+        /// </summary>
+        /// <param name="elementName">Name of the element.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
         public YAXElementValueAlreadyExistsException(string elementName, IXmlLineInfo lineInfo) :
             base(lineInfo)
@@ -330,6 +357,15 @@ namespace YAXLib
         /// Initializes a new instance of the <see cref="YAXElementMissingException"/> class.
         /// </summary>
         /// <param name="elemName">Name of the element.</param>
+        public YAXElementMissingException(string elemName) :
+            this(elemName, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXElementMissingException"/> class.
+        /// </summary>
+        /// <param name="elemName">Name of the element.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
         public YAXElementMissingException(string elemName, IXmlLineInfo lineInfo) :
             base(lineInfo)
@@ -373,6 +409,16 @@ namespace YAXLib
     public class YAXBadlyFormedInput : YAXDeserializationException
     {
         #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXBadlyFormedInput"/> class.
+        /// </summary>
+        /// <param name="elemName">Name of the element.</param>
+        /// <param name="badInput">The value of the input which could not be converted to the type of the property.</param>
+        public YAXBadlyFormedInput(string elemName, string badInput)
+            : this(elemName, badInput, null)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YAXBadlyFormedInput"/> class.
@@ -438,6 +484,15 @@ namespace YAXLib
         /// <summary>
         /// Initializes a new instance of the <see cref="YAXPropertyCannotBeAssignedTo"/> class.
         /// </summary>
+        /// <param name="propName">Name of the property.</param>      
+        public YAXPropertyCannotBeAssignedTo(string propName) :
+            this(propName, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXPropertyCannotBeAssignedTo"/> class.
+        /// </summary>
         /// <param name="propName">Name of the property.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>        
         public YAXPropertyCannotBeAssignedTo(string propName, IXmlLineInfo lineInfo) :
@@ -481,6 +536,16 @@ namespace YAXLib
     public class YAXCannotAddObjectToCollection : YAXDeserializationException
     {
         #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXCannotAddObjectToCollection"/> class.
+        /// </summary>
+        /// <param name="propName">Name of the property.</param>
+        /// <param name="obj">The object that could not be added to the collection.</param>
+        public YAXCannotAddObjectToCollection(string propName, object obj) :
+            this(propName, obj, null)
+        {            
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YAXCannotAddObjectToCollection"/> class.
@@ -541,6 +606,16 @@ namespace YAXLib
     public class YAXDefaultValueCannotBeAssigned : YAXDeserializationException
     {
         #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXDefaultValueCannotBeAssigned"/> class.
+        /// </summary>
+        /// <param name="propName">Name of the property.</param>
+        /// <param name="defaultValue">The default value which caused the problem.</param>
+        public YAXDefaultValueCannotBeAssigned(string propName, object defaultValue) :
+            this(propName, defaultValue, null)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YAXDefaultValueCannotBeAssigned"/> class.

--- a/YAXLib/YAXExceptions.cs
+++ b/YAXLib/YAXExceptions.cs
@@ -60,6 +60,18 @@ namespace YAXLib
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="YAXDeserializationException"/> class.
+        /// </summary>
+        /// <param name="lineNumber">The line number on which the error occurred</param>
+        /// <param name="linePosition">The line position on which the error occurred</param>
+        public YAXDeserializationException(int lineNumber, int linePosition)
+        {
+            HasLineInfo = true;
+            LineNumber = lineNumber;
+            LinePosition = linePosition;            
+        }
+
+        /// <summary>
         /// Gets whether the exception has line information
         /// Note: if this is unexpectedly false, then most likely you need to specify LoadOptions.SetLineInfo on document load
         /// </summary>
@@ -79,7 +91,7 @@ namespace YAXLib
         /// Position string for use in error message
         /// </summary>
         protected string LineInfoMessage => HasLineInfo
-            ? string.Format(CultureInfo.CurrentCulture, " (line {0}, position {1})", LineNumber, LinePosition)
+            ? string.Format(CultureInfo.CurrentCulture, " Line {0}, position {1}.", LineNumber, LinePosition)
             : string.Empty;
     }
 
@@ -224,7 +236,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "No attributes with this name found: '{0}'{1}.", this.AttributeName, this.LineInfoMessage);
+                return String.Format(CultureInfo.CurrentCulture, "No attributes with this name found: '{0}'.{1}", this.AttributeName, this.LineInfoMessage);
             }
         }
 
@@ -280,7 +292,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Element with the given name does not contain text values: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
+                return String.Format(CultureInfo.CurrentCulture, "Element with the given name does not contain text values: '{0}'.{1}", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -337,7 +349,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Element with the given name already has value: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
+                return String.Format(CultureInfo.CurrentCulture, "Element with the given name already has value: '{0}'.{1}", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -394,7 +406,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "No elements with this name found: '{0}'{1}.", this.ElementName, this.LineInfoMessage);
+                return String.Format(CultureInfo.CurrentCulture, "No elements with this name found: '{0}'.{1}", this.ElementName, this.LineInfoMessage);
             }
         }
 
@@ -462,7 +474,7 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "The format of the value specified for the property '{0}' is not proper: '{1}'{2}.",                    
+                    "The format of the value specified for the property '{0}' is not proper: '{1}'.{2}",                    
                     this.ElementName,
                     this.BadInput, 
                     this.LineInfoMessage);
@@ -522,7 +534,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Could not assign to the property '{0}'{1}.", this.PropertyName, this.LineInfoMessage);
+                return String.Format(CultureInfo.CurrentCulture, "Could not assign to the property '{0}'.{1}", this.PropertyName, this.LineInfoMessage);
             }
         }
 
@@ -589,7 +601,7 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "Could not add object ('{0}') to the collection ('{1}'){2}.",                    
+                    "Could not add object ('{0}') to the collection ('{1}').{2}",                    
                     this.ObjectToAdd,
                     this.PropertyName, 
                     this.LineInfoMessage);
@@ -659,7 +671,7 @@ namespace YAXLib
             {
                 return String.Format(
                     CultureInfo.CurrentCulture,
-                    "Could not assign the default value specified ('{0}') for the property '{1}'{2}.",                    
+                    "Could not assign the default value specified ('{0}') for the property '{1}'.{2}",                    
                     this.TheDefaultValue,
                     this.PropertyName, 
                     this.LineInfoMessage);
@@ -673,7 +685,7 @@ namespace YAXLib
     /// Raised when the XML input does not follow standard XML formatting rules.
     /// This exception is raised during deserialization.
     /// </summary>
-    public class YAXBadlyFormedXML : YAXException
+    public class YAXBadlyFormedXML : YAXDeserializationException
     {
         #region Fields
 
@@ -690,7 +702,20 @@ namespace YAXLib
         /// Initializes a new instance of the <see cref="YAXBadlyFormedXML"/> class.
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
+        /// <param name="lineNumber">The line number on which the error occurred</param>
+        /// <param name="linePosition">The line position on which the error occurred</param>
+        public YAXBadlyFormedXML(Exception innerException, int lineNumber, int linePosition)
+            : base(lineNumber, linePosition)
+        {
+            this.innerException = innerException;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YAXBadlyFormedXML"/> class.
+        /// </summary>
+        /// <param name="innerException">The inner exception.</param>
         public YAXBadlyFormedXML(Exception innerException) 
+            : base(null)
         {
             this.innerException = innerException;
         }
@@ -699,6 +724,7 @@ namespace YAXLib
         /// Initializes a new instance of the <see cref="YAXBadlyFormedXML"/> class.
         /// </summary>       
         public YAXBadlyFormedXML() 
+            : this(null)
         {
         }
 
@@ -717,7 +743,7 @@ namespace YAXLib
         {
             get
             {
-                string msg = "The input xml file is not properly formatted!";
+                string msg = string.Format(CultureInfo.CurrentCulture, "The input xml file is not properly formatted!{0}", this.LineInfoMessage);
 
                 if (this.innerException != null)
                 {

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -44,6 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Bin\YAXLib.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -54,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Bin\YAXLib.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -415,7 +415,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
                 return null;
             }
         }
@@ -436,7 +436,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
                 return null;
             }
         }
@@ -457,7 +457,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
                 return null;
             }
         }
@@ -478,7 +478,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
                 return null;
             }
         }
@@ -496,7 +496,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
                 return null;
             }
         }

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -407,7 +407,7 @@ namespace YAXLib
             {
                 using (TextReader tr = new StringReader(input))
                 {
-                    var xdoc = XDocument.Load(tr, LoadOptions.SetLineInfo);
+                    var xdoc = XDocument.Load(tr, GetXmlLoadOptions());
                     var baseElement = xdoc.Root;
                     FindDocumentDefaultNamespace();
                     return DeserializeBase(baseElement);
@@ -429,7 +429,7 @@ namespace YAXLib
         {
             try
             {
-                XDocument xdoc = XDocument.Load(xmlReader, LoadOptions.SetLineInfo);
+                XDocument xdoc = XDocument.Load(xmlReader, GetXmlLoadOptions());
                 XElement baseElement = xdoc.Root;
                 FindDocumentDefaultNamespace();
                 return DeserializeBase(baseElement);
@@ -450,7 +450,7 @@ namespace YAXLib
         {
             try
             {
-                XDocument xdoc = XDocument.Load(textReader, LoadOptions.SetLineInfo);
+                XDocument xdoc = XDocument.Load(textReader, GetXmlLoadOptions());
                 XElement baseElement = xdoc.Root;
                 FindDocumentDefaultNamespace();
                 return DeserializeBase(baseElement);
@@ -2816,6 +2816,20 @@ namespace YAXLib
                 RegisterNamespace(m_yaxLibNamespaceUri, m_yaxLibNamespacePrefix);
             }
         }
+
+        /// <summary>
+        /// Generates XDocument LoadOptions from SerializationOption
+        /// </summary>
+        private LoadOptions GetXmlLoadOptions()
+        {
+            LoadOptions options = LoadOptions.None;
+            if (m_serializationOption.HasFlag(YAXSerializationOptions.DisplayLineInfoInExceptions))
+            {
+                options |= LoadOptions.SetLineInfo;
+            }
+            return options;
+        }
+
 
         /// <summary>
         /// Called when an exception occurs inside the library. It applies the exception handling policies.

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -1719,7 +1719,7 @@ namespace YAXLib
                             catch
                             {
                                 OnExceptionOccurred(
-                                    new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue, (IXmlLineInfo)xattrValue ?? xelemValue ?? baseElement),
+                                    new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue, xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo),
                                     m_defaultExceptionType);
                             }
                         }
@@ -1732,7 +1732,7 @@ namespace YAXLib
                             catch
                             {
                                 OnExceptionOccurred(
-                                    new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue, (IXmlLineInfo)xattrValue ?? xelemValue ?? baseElement),
+                                    new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue, xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo),
                                     m_defaultExceptionType);
                             }
                         }
@@ -1775,7 +1775,7 @@ namespace YAXLib
                     }
                     catch
                     {
-                        OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, (IXmlLineInfo)xattrValue ?? xelemValue ?? baseElement), m_defaultExceptionType);
+                        OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo), m_defaultExceptionType);
                     }
                 }
                 else if (elemValue != null)

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -176,7 +176,10 @@ namespace YAXLibTests
         {
             var testName = "Test";
 
-            Exception ex = Assert.Throws<YAXBadLocationException>(() => throw new YAXBadLocationException(testName));
+            Exception ex = Assert.Throws<YAXBadLocationException>(() =>
+            {
+                throw new YAXBadLocationException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -184,7 +187,10 @@ namespace YAXLibTests
         public void YAXAttributeAlreadyExistsExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXAttributeAlreadyExistsException>(() => throw new YAXAttributeAlreadyExistsException(testName));
+            var ex = Assert.Throws<YAXAttributeAlreadyExistsException>(() =>
+            {
+                throw new YAXAttributeAlreadyExistsException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -192,7 +198,10 @@ namespace YAXLibTests
         public void YAXAttributeMissingExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXAttributeMissingException>(() => throw new YAXAttributeMissingException(testName));
+            var ex = Assert.Throws<YAXAttributeMissingException>(() =>
+            {
+                throw new YAXAttributeMissingException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -200,7 +209,10 @@ namespace YAXLibTests
         public void YAXElementValueMissingExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXElementValueMissingException>(() => throw new YAXElementValueMissingException(testName));
+            var ex = Assert.Throws<YAXElementValueMissingException>(() =>
+            {
+                throw new YAXElementValueMissingException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -208,7 +220,10 @@ namespace YAXLibTests
         public void YAXElementValueAlreadyExistsExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXElementValueAlreadyExistsException>(() => throw new YAXElementValueAlreadyExistsException(testName));
+            var ex = Assert.Throws<YAXElementValueAlreadyExistsException>(() =>
+            {
+                throw new YAXElementValueAlreadyExistsException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -216,7 +231,10 @@ namespace YAXLibTests
         public void YAXElementMissingExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXElementMissingException>(() => throw new YAXElementMissingException(testName));
+            var ex = Assert.Throws<YAXElementMissingException>(() =>
+            {
+                throw new YAXElementMissingException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -225,7 +243,10 @@ namespace YAXLibTests
         {
             var testName = "Test";
             var testInput = "BadInput";
-            var ex = Assert.Throws<YAXBadlyFormedInput>(() => throw new YAXBadlyFormedInput(testName, testInput));
+            var ex = Assert.Throws<YAXBadlyFormedInput>(() =>
+            {
+                throw new YAXBadlyFormedInput(testName, testInput);
+            });
             StringAssert.Contains(testName, ex.Message);
             StringAssert.Contains(testInput, ex.Message);
         }
@@ -234,7 +255,10 @@ namespace YAXLibTests
         public void YAXPropertyCannotBeAssignedToLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXPropertyCannotBeAssignedTo>(() => throw new YAXPropertyCannotBeAssignedTo(testName));
+            var ex = Assert.Throws<YAXPropertyCannotBeAssignedTo>(() =>
+            {
+                throw new YAXPropertyCannotBeAssignedTo(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -243,7 +267,10 @@ namespace YAXLibTests
         {
             var testName = "Test";
             var testValue = 1;
-            var ex = Assert.Throws<YAXCannotAddObjectToCollection>(() => throw new YAXCannotAddObjectToCollection(testName, testValue));
+            var ex = Assert.Throws<YAXCannotAddObjectToCollection>(() =>
+            {
+                throw new YAXCannotAddObjectToCollection(testName, testValue);
+            });
             StringAssert.Contains(testName, ex.Message);
             StringAssert.Contains(testValue.ToString(), ex.Message);
         }
@@ -253,7 +280,10 @@ namespace YAXLibTests
         {
             var testName = "Test";
             var testValue = 1;
-            var ex = Assert.Throws<YAXDefaultValueCannotBeAssigned>(() => throw new YAXDefaultValueCannotBeAssigned(testName, testValue));
+            var ex = Assert.Throws<YAXDefaultValueCannotBeAssigned>(() =>
+            {
+                throw new YAXDefaultValueCannotBeAssigned(testName, testValue);
+            });
             StringAssert.Contains(testName, ex.Message);
             StringAssert.Contains(testValue.ToString(), ex.Message);
         }
@@ -262,7 +292,10 @@ namespace YAXLibTests
         public void YAXBadlyFormedXMLLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXBadlyFormedXML>(() => throw new YAXBadlyFormedXML(new Exception(testName)));
+            var ex = Assert.Throws<YAXBadlyFormedXML>(() =>
+            {
+                throw new YAXBadlyFormedXML(new Exception(testName));
+            });
             StringAssert.Contains(testName, ex.Message);
         }
 
@@ -271,7 +304,10 @@ namespace YAXLibTests
         {
             var testInput = "BadInput";
             var testType = typeof(string);
-            var ex = Assert.Throws<YAXInvalidFormatProvided>(() => throw new YAXInvalidFormatProvided(testType, testInput));
+            var ex = Assert.Throws<YAXInvalidFormatProvided>(() =>
+            {
+                throw new YAXInvalidFormatProvided(testType, testInput);
+            });
             StringAssert.Contains(testType.Name, ex.Message);
             StringAssert.Contains(testInput, ex.Message);
         }
@@ -280,7 +316,10 @@ namespace YAXLibTests
         public void YAXCannotSerializeSelfReferentialTypesLegacyConstructor()
         {
             var testType = typeof(string);
-            var ex = Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() => throw new YAXCannotSerializeSelfReferentialTypes(testType));
+            var ex = Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() =>
+            {
+                throw new YAXCannotSerializeSelfReferentialTypes(testType);
+            });
             StringAssert.Contains(testType.Name, ex.Message);
         }
 
@@ -289,7 +328,10 @@ namespace YAXLibTests
         {
             var testType = typeof(string);
             var testType2 = typeof(int);
-            var ex = Assert.Throws<YAXObjectTypeMismatch>(() => throw new YAXObjectTypeMismatch(testType, testType2));
+            var ex = Assert.Throws<YAXObjectTypeMismatch>(() =>
+            {
+                throw new YAXObjectTypeMismatch(testType, testType2);
+            });
             StringAssert.Contains(testType.Name, ex.Message);
             StringAssert.Contains(testType2.Name, ex.Message);
         }
@@ -298,7 +340,10 @@ namespace YAXLibTests
         public void YAXPolymorphicExceptionLegacyConstructor()
         {
             var testName = "Test";
-            var ex = Assert.Throws<YAXPolymorphicException>(() => throw new YAXPolymorphicException(testName));
+            var ex = Assert.Throws<YAXPolymorphicException>(() =>
+            {
+                throw new YAXPolymorphicException(testName);
+            });
             StringAssert.Contains(testName, ex.Message);
 
         }

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -33,7 +33,30 @@ namespace YAXLibTests
         }
 
         [Test]
-        public void YAXBadlyFormedInputTest()
+        public void YAXBadlyFormedInputWithLineNumbersTest()
+        {
+            const string bookXml =
+                @"<!-- This example demonstrates serailizing a very simple class -->
+<Book>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+  <Price>BADDATA</Price>
+</Book>";
+
+            var ex = Assert.Throws<YAXBadlyFormedInput>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error, YAXSerializationOptions.DisplayLineInfoInExceptions);
+                serializer.Deserialize(bookXml);
+            });
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(6, ex.LineNumber);
+            Assert.AreEqual(4, ex.LinePosition);
+            StringAssert.Contains("The format of the value specified for the property", ex.Message);
+        }
+
+        [Test]
+        public void YAXBadlyFormedInputWithoutLineNumbersTest()
         {
             const string bookXml =
                 @"<!-- This example demonstrates serailizing a very simple class -->
@@ -49,12 +72,11 @@ namespace YAXLibTests
                 var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error);
                 serializer.Deserialize(bookXml);
             });
-            Assert.True(ex.HasLineInfo);
-            Assert.AreEqual(6, ex.LineNumber);
-            Assert.AreEqual(4, ex.LinePosition);
+            Assert.False(ex.HasLineInfo);
+            Assert.AreEqual(0, ex.LineNumber);
+            Assert.AreEqual(0, ex.LinePosition);
             StringAssert.Contains("The format of the value specified for the property", ex.Message);
         }
-
 
         [Test]
         public void YAXObjectTypeMismatchExceptionTest()

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -23,14 +23,28 @@ namespace YAXLibTests
         [Test]
         public void YAXBadlyFormedXMLTest()
         {
+            string badXml = @"<!-- This example demonstrates serailizing a very simple class -->
+<Book>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+  <Price>BADDATA<Price>
+</Book>";
+
             var ex = Assert.Throws<YAXBadlyFormedXML>(() =>
             {
                 var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error);
-                serializer.Deserialize("some garbage!");
+                serializer.Deserialize(badXml);
             });
 
+            // YAXBadlyFormedXML exception doesn't need YAXSerializationOptions.DisplayLineInfoInExceptions to get the line numbers
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(7, ex.LineNumber);
+            Assert.AreEqual(3, ex.LinePosition);
             StringAssert.Contains("not properly formatted", ex.Message);
+            
         }
+        
 
         [Test]
         public void YAXBadlyFormedInputWithLineNumbersTest()
@@ -156,5 +170,6 @@ namespace YAXLibTests
             Assert.AreEqual(1, ex.LineNumber);
             Assert.AreEqual(2, ex.LinePosition);
         }
+        
     }
 }

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -93,5 +93,68 @@ namespace YAXLibTests
             StringAssert.Contains("'ClassWithDuplicateYaxAttribute'", ex.Message);
         }
 
+
+        [Test]
+        public void YAXElementValueMissingWithLineNumbersTest()
+        {
+            const string bookXml =
+                @"<!-- This example demonstrates serailizing a very simple class -->
+<Book>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+</Book>";
+
+            var ex = Assert.Throws<YAXElementValueMissingException>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(BookClassTesgingSerializeAsValue), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error, YAXSerializationOptions.DisplayLineInfoInExceptions);
+                serializer.Deserialize(bookXml);
+            });
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(2, ex.LineNumber);
+            Assert.AreEqual(2, ex.LinePosition);
+        }
+
+        [Test]
+        public void YAXElementMissingWithLineNumbersTest()
+        {
+            const string collectionXml =
+@"<!-- This example demonstrates serailizing a very simple class -->
+<CollectionSeriallyAsAttribute>
+  <Info names=""John Doe, Jane, Sina, Mike, Rich"" />
+  <Location>
+    <Countries> Iran,Australia,United States of America, France</Countries>
+  </Location>
+</CollectionSeriallyAsAttribute> ";
+
+            var ex = Assert.Throws<YAXElementMissingException>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(CollectionSeriallyAsAttribute), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error, YAXSerializationOptions.DisplayLineInfoInExceptions);
+                serializer.Deserialize(collectionXml);
+            });
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(2, ex.LineNumber);
+            Assert.AreEqual(2, ex.LinePosition);
+        }
+        
+        [Test]
+        public void YAXDefaultValueCannotBeAssignedWithLineNumbersTest()
+        {
+            const string bookXml =
+                @"<Book>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+</Book>";
+
+            var ex = Assert.Throws<YAXDefaultValueCannotBeAssigned>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(BookWithBadDefaultValue), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error, YAXSerializationOptions.DisplayLineInfoInExceptions);
+                serializer.Deserialize(bookXml);
+            });
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(1, ex.LineNumber);
+            Assert.AreEqual(2, ex.LinePosition);
+        }
     }
 }

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -33,6 +33,30 @@ namespace YAXLibTests
         }
 
         [Test]
+        public void YAXBadlyFormedInputTest()
+        {
+            const string bookXml =
+                @"<!-- This example demonstrates serailizing a very simple class -->
+<Book>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+  <Price>BADDATA</Price>
+</Book>";
+
+            var ex = Assert.Throws<YAXBadlyFormedInput>(() =>
+            {
+                var serializer = new YAXSerializer(typeof(Book), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error);
+                serializer.Deserialize(bookXml);
+            });
+            Assert.True(ex.HasLineInfo);
+            Assert.AreEqual(6, ex.LineNumber);
+            Assert.AreEqual(4, ex.LinePosition);
+            StringAssert.Contains("The format of the value specified for the property", ex.Message);
+        }
+
+
+        [Test]
         public void YAXObjectTypeMismatchExceptionTest()
         {
             var ex = Assert.Throws<YAXObjectTypeMismatch>(() =>

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -170,6 +170,137 @@ namespace YAXLibTests
             Assert.AreEqual(1, ex.LineNumber);
             Assert.AreEqual(2, ex.LinePosition);
         }
+
+        [Test]
+        public void YAXBadLocationExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+
+            Exception ex = Assert.Throws<YAXBadLocationException>(() => throw new YAXBadLocationException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXAttributeAlreadyExistsExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXAttributeAlreadyExistsException>(() => throw new YAXAttributeAlreadyExistsException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXAttributeMissingExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXAttributeMissingException>(() => throw new YAXAttributeMissingException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXElementValueMissingExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXElementValueMissingException>(() => throw new YAXElementValueMissingException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXElementValueAlreadyExistsExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXElementValueAlreadyExistsException>(() => throw new YAXElementValueAlreadyExistsException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXElementMissingExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXElementMissingException>(() => throw new YAXElementMissingException(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXBadlyFormedInputLegacyConstructor()
+        {
+            var testName = "Test";
+            var testInput = "BadInput";
+            var ex = Assert.Throws<YAXBadlyFormedInput>(() => throw new YAXBadlyFormedInput(testName, testInput));
+            StringAssert.Contains(testName, ex.Message);
+            StringAssert.Contains(testInput, ex.Message);
+        }
+
+        [Test]
+        public void YAXPropertyCannotBeAssignedToLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXPropertyCannotBeAssignedTo>(() => throw new YAXPropertyCannotBeAssignedTo(testName));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXCannotAddObjectToCollectionLegacyConstructor()
+        {
+            var testName = "Test";
+            var testValue = 1;
+            var ex = Assert.Throws<YAXCannotAddObjectToCollection>(() => throw new YAXCannotAddObjectToCollection(testName, testValue));
+            StringAssert.Contains(testName, ex.Message);
+            StringAssert.Contains(testValue.ToString(), ex.Message);
+        }
+
+        [Test]
+        public void YAXDefaultValueCannotBeAssignedLegacyConstructor()
+        {
+            var testName = "Test";
+            var testValue = 1;
+            var ex = Assert.Throws<YAXDefaultValueCannotBeAssigned>(() => throw new YAXDefaultValueCannotBeAssigned(testName, testValue));
+            StringAssert.Contains(testName, ex.Message);
+            StringAssert.Contains(testValue.ToString(), ex.Message);
+        }
         
+        [Test]
+        public void YAXBadlyFormedXMLLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXBadlyFormedXML>(() => throw new YAXBadlyFormedXML(new Exception(testName)));
+            StringAssert.Contains(testName, ex.Message);
+        }
+
+        [Test]
+        public void YAXInvalidFormatProvidedLegacyConstructor()
+        {
+            var testInput = "BadInput";
+            var testType = typeof(string);
+            var ex = Assert.Throws<YAXInvalidFormatProvided>(() => throw new YAXInvalidFormatProvided(testType, testInput));
+            StringAssert.Contains(testType.Name, ex.Message);
+            StringAssert.Contains(testInput, ex.Message);
+        }
+
+        [Test]
+        public void YAXCannotSerializeSelfReferentialTypesLegacyConstructor()
+        {
+            var testType = typeof(string);
+            var ex = Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() => throw new YAXCannotSerializeSelfReferentialTypes(testType));
+            StringAssert.Contains(testType.Name, ex.Message);
+        }
+
+        [Test]
+        public void YAXObjectTypeMismatchLegacyConstructor()
+        {
+            var testType = typeof(string);
+            var testType2 = typeof(int);
+            var ex = Assert.Throws<YAXObjectTypeMismatch>(() => throw new YAXObjectTypeMismatch(testType, testType2));
+            StringAssert.Contains(testType.Name, ex.Message);
+            StringAssert.Contains(testType2.Name, ex.Message);
+        }
+
+        [Test]
+        public void YAXPolymorphicExceptionLegacyConstructor()
+        {
+            var testName = "Test";
+            var ex = Assert.Throws<YAXPolymorphicException>(() => throw new YAXPolymorphicException(testName));
+            StringAssert.Contains(testName, ex.Message);
+
+        }
     }
 }

--- a/YAXLibTests/SampleClasses/Code4PublicTheme.cs
+++ b/YAXLibTests/SampleClasses/Code4PublicTheme.cs
@@ -200,7 +200,7 @@ namespace YAXLibTests.SampleClasses
             if (TryParseColor(attrib.Value, out color))
                 return color;
 
-            throw new YAXBadlyFormedInput(attrib.Name.ToString(), attrib.Value);
+            throw new YAXBadlyFormedInput(attrib.Name.ToString(), attrib.Value, attrib);
         }
 
         public Color DeserializeFromElement(XElement element)
@@ -209,7 +209,7 @@ namespace YAXLibTests.SampleClasses
             if (TryParseColor(element.Value, out color))
                 return color;
 
-            throw new YAXBadlyFormedInput(element.Name.ToString(), element.Value);
+            throw new YAXBadlyFormedInput(element.Name.ToString(), element.Value, element);
         }
 
         public Color DeserializeFromValue(string value)
@@ -218,7 +218,7 @@ namespace YAXLibTests.SampleClasses
             if (TryParseColor(value, out color))
                 return color;
 
-            throw new YAXBadlyFormedInput("[SomeValue]", value);
+            throw new YAXBadlyFormedInput("[SomeValue]", value, null);
         }
 
                     public static string ColorTo8CharString(Color color)

--- a/YAXLibTests/SampleClasses/SimpleBookClassWithBadDefaultValue.cs
+++ b/YAXLibTests/SampleClasses/SimpleBookClassWithBadDefaultValue.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses
+{
+    [ShowInDemoApplication(SortKey="001")]
+
+    [YAXComment("This example demonstrates serailizing a very simple class")]
+    public class BookWithBadDefaultValue
+    {
+        public string Title { get; set; }
+        public string Author { get; set; }
+        public int PublishYear { get; set; }
+
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = "NOTDOUBLE")]
+        public double Price { get; set; }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public static Book GetSampleInstance()
+        {
+            return new Book()
+            {
+                Title = "Inside C#",
+                Author = "Tom Archer & Andrew Whitechapel",
+                PublishYear = 2002,
+                Price = 30.5
+            };
+        }
+    }
+}

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="SampleClasses\SelfReferencingObjects\RepetitiveReferenceIsNotLoop.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\IndirectSelfReferringObject.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\DirectSelfReferringObject.cs" />
+    <Compile Include="SampleClasses\SimpleBookClassWithBadDefaultValue.cs" />
     <Compile Include="SampleClasses\SimpleBookClassWithOrdering.cs" />
     <Compile Include="SampleClasses\SingleLetterPropertyNames.cs" />
     <Compile Include="SampleClasses\YAXLibMetadataOverriding.cs" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ clone_folder: c:\xaxlib
 version: 2.15.{build}
 
 build_script:
-- ps: nuget restore YAXLib.2015.Core.sln -verbosity quiet
+- ps: dotnet restore --verbosity quiet
 - ps: msbuild YAXLib.2015.Core.sln /verbosity:minimal /t:rebuild /p:configuration=release
 - ps: nuget restore YAXLib.2015.sln -verbosity quiet
 - ps: msbuild YAXLib.2015.sln /verbosity:minimal /t:rebuild /p:configuration=release


### PR DESCRIPTION
Hi, 
I really like the library. Very useful for parsing some slightly non-standard and illogically structured XML documents I have to deal with. However, I was finding it frustrating attempting to debug the deserialization of some large XML files when I was getting errors without any indication of where they were occurring in the XML document. 
I've added an extra serializer option to allow it to track line numbers and positions using the LoadOptions.SetLineInfo option for the XDocument.Load method. I've created a YAXDeserializationException base class for any exceptions thrown during deserialization, which then contain the line number and position if it's available. This is then added to the exception message for all the relevant exceptions.

I've left this option turned off by default as there appears to be a bit of performance hit to having it turned on (mentioned here: https://msdn.microsoft.com/en-us/library/system.xml.linq.loadoptions(v=vs.110).aspx). I did some very unscientific testing and I added two new tests, one with and one without line numbers, which do a single run on a very small chunk of XML. On my machine the line number one appears to take roughly 10x as long each time (30ms vs 3ms).

Anyway, hope someone else also finds this useful. 

Cheers,

Rich
